### PR TITLE
Do not ignore SIGTERM, is needed for the dyno (workers) to exit correctly

### DIFF
--- a/bin/start-stunnel
+++ b/bin/start-stunnel
@@ -21,7 +21,7 @@ run-stunnel() {
   mkfifo "$sentinel"
 
   # Start processes.
-  aux-start stunnel SIGINT stunnel4 vendor/stunnel/stunnel.conf
+  aux-start stunnel SIGTERM stunnel4 vendor/stunnel/stunnel.conf
   app-start SIGTERM "$@"
   pid=$!
   pgid=$(ps -o pgid= $pid | xargs)


### PR DESCRIPTION
Ignoring SIGTERM will make non web dynos to finish unexpectedly, and we need faktory workers to end correctly, they need to receive the signal to start the shutdown process, so the job ends on a failed state instead of disappearing and the queue server waiting for the job's timeout.